### PR TITLE
JDKversionの明記、javaxAPI用にAPIを追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--  JDK version -->
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
   <modelVersion>4.0.0</modelVersion>
   <groupId>jp.ne.bold</groupId>
   <artifactId>Apollon</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>war</packaging>
+  <dependencies>
+   <dependency>
+     <groupId>javax</groupId>
+     <artifactId>javaee-api</artifactId>
+     <version>8.0.1-b5</version>
+     <scope>provided</scope>
+   </dependency>
+  </dependencies>
 </project>

--- a/target/m2e-wtp/web-resources/META-INF/maven/jp.ne.bold/Apollon/pom.xml
+++ b/target/m2e-wtp/web-resources/META-INF/maven/jp.ne.bold/Apollon/pom.xml
@@ -1,7 +1,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--  JDK version -->
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
   <modelVersion>4.0.0</modelVersion>
   <groupId>jp.ne.bold</groupId>
   <artifactId>Apollon</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>war</packaging>
+  <dependencies>
+   <dependency>
+     <groupId>javax</groupId>
+     <artifactId>javaee-api</artifactId>
+     <version>8.0.1-b5</version>
+     <scope>provided</scope>
+   </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
お疲れ様です。

ビルド・エラーについて調査した結果、問題は以下にあることがわかりました。
・コンパイラ準拠レベルがJDK1.5。
・JREライブラリがJRE1.5であるため、ビルドエラーが発生した。
・javaee-apiの依存性指定がされていないため、クラスが見つからずにエラーが発生した。

上記問題を解決するためにpom.xmlに定義を追加しております。
これにより、Mavenを実行すると以下の設定を自動で実行するようになります。
・コンパイラ準拠レベルをJDK1.8に指定
・JREライブラリの自動設定
・javaee-apiライブラリのインストール

他にもsettings配下のorg.eclipse.wst.common.project.facet.core.xmlの設定も見直しが必要かと思います。
動的webモジュールの設定を2.5にしたらビルドが通りましたが、長門さんが意図的に直されているようなのでとりあえず修正は保留にしました。
(これはGlassFish5にしていることが原因かもしれませんね。)

ひとまず共通資産なので、別枠でプルリクエストしました！
ご確認のほど、よろしくお願いいたします！